### PR TITLE
Add extra go mod tidy before build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Build
-        run: go build -v ./...
+        run: |
+          go mod tidy
+          go build -v ./...
 
       - name: Test
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM golang:1.23 as build
 
-ADD . /app
 WORKDIR /app
 
+COPY go.mod go.sum .
+RUN go mod download
+
+ADD . /app
+
+RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build
 
 FROM alpine:3.20


### PR DESCRIPTION
For PRs that modify dependencies, we'll need to run tidy before build again to make sure all dependencies are updated in the mod file.