### PR TITLE
Add a cache to the IsWTFIsMyIpOffline function

### DIFF
--- a/server.go
+++ b/server.go
@@ -52,7 +52,7 @@ func getRouter(ipv4Only bool) (*http.ServeMux, error) {
 		}
 
 		if ssproxy.IsWTFIsMyIpOffline() {
-			log.Errorf("https://wtfismyip.com is having problems %v", err)
+			log.Errorf("https://wtfismyip.com is having problems")
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}

--- a/ssproxy/offline_cache.go
+++ b/ssproxy/offline_cache.go
@@ -1,0 +1,37 @@
+package ssproxy
+
+import (
+	"sync"
+	"time"
+)
+
+type safeIsOfflineCache struct {
+	isOffline          bool
+	offlineCacheExpiry time.Time
+	mu                 sync.Mutex
+}
+
+func (s *safeIsOfflineCache) expired() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return time.Now().After(s.offlineCacheExpiry)
+}
+
+func (s *safeIsOfflineCache) setIsOfflineToCache(offlineCache bool, expiry time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.isOffline = offlineCache
+	s.offlineCacheExpiry = time.Now().Add(expiry)
+}
+
+func (s *safeIsOfflineCache) getIsOfflineFromCache() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.isOffline
+}
+
+func (s *safeIsOfflineCache) isZero() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.offlineCacheExpiry.IsZero()
+}


### PR DESCRIPTION
we don't need to spam wtfismyip.com every time we do a request. I think a 5 minutes cache should be enough to make sure upstream is available.
